### PR TITLE
Enable true thread-based concurrency for ParallelBatchNode & ParallelBatchFlow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Architecture Overview
 
-PocketFlow Ruby is a synchronous workflow orchestration library for Ruby 2.5+ ported from TypeScript, designed around a simple node-graph execution model. The entire library is contained in a single file: `lib/pocketflow.rb`.
+PocketFlow Ruby is a synchronous workflow orchestration library for Ruby 2.7+ ported from TypeScript, designed around a simple node-graph execution model. The entire library is contained in a single file: `lib/pocketflow.rb`.
 
 ### Core Components
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Architecture Overview
 
-PocketFlow Ruby is a synchronous workflow orchestration library ported from TypeScript, designed around a simple node-graph execution model. The entire library is contained in a single file: `lib/pocketflow.rb`.
+PocketFlow Ruby is a synchronous workflow orchestration library for Ruby 2.5+ ported from TypeScript, designed around a simple node-graph execution model. The entire library is contained in a single file: `lib/pocketflow.rb`.
 
 ### Core Components
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,9 +8,9 @@ PocketFlow Ruby is a synchronous workflow orchestration library ported from Type
 
 - **BaseNode**: The fundamental execution unit with `prep → exec → post` lifecycle
 - **Node**: Extends BaseNode with retry/wait behavior around `exec`
-- **BatchNode/ParallelBatchNode**: Process arrays sequentially (parallel variants run sequentially for now)
+- **BatchNode/ParallelBatchNode**: Process arrays sequentially/concurrently using threads
 - **Flow**: Orchestrates node execution following action-based transitions
-- **BatchFlow/ParallelBatchFlow**: Execute flows once per parameter set
+- **BatchFlow/ParallelBatchFlow**: Execute flows once per parameter set, sequentially/concurrently
 
 ### Key Patterns
 
@@ -44,13 +44,18 @@ review_node.on("approved", payment_node)
 
 **Node Composition**: Build complex workflows by composing simple, single-purpose nodes rather than monolithic ones.
 
+**Concurrency**: Use `ParallelBatchNode` and `ParallelBatchFlow` for I/O-bound tasks like LLM API calls and shell commands where Ruby's GVL is released for true parallelism.
+
+**Thread Safety**: Parallel nodes automatically handle thread safety by cloning node instances and safely merging shared context results.
+
 ## Common Patterns from Tests
 
 **QA Pattern**: Question → Answer flow with shared context passing
 **RAG Pattern**: Chunk → Embed → Store → Query → Retrieve → Generate pipeline
-**MapReduce**: BatchNode for mapping, followed by reduction node
+**MapReduce**: BatchNode for mapping, followed by reduction node (use ParallelBatchNode for concurrent mapping)
 **Multi-Agent**: Self-referencing nodes with queue-based message passing
 **Conditional Branching**: Use `post` return values to route between different node paths
+**Concurrent I/O**: ParallelBatchNode/ParallelBatchFlow for API calls, shell commands, file operations
 
 ## Testing Patterns
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,14 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.4.2'
+          - '2.5'
+          - '2.6'
+          - '2.7'
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
+          - '3.4'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.5'
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
@@ -25,10 +23,6 @@ jobs:
           - '3.4'
         include:
           # Use older bundler for Ruby < 3.1 to avoid compatibility issues
-          - ruby: '2.5'
-            bundler: '2.3.26'
-          - ruby: '2.6'
-            bundler: '2.3.26'
           - ruby: '2.7'
             bundler: '2.3.26'
           - ruby: '3.0'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - '2.5'
@@ -22,6 +23,16 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+        include:
+          # Use older bundler for Ruby < 3.1 to avoid compatibility issues
+          - ruby: '2.5'
+            bundler: '2.3.26'
+          - ruby: '2.6'
+            bundler: '2.3.26'
+          - ruby: '2.7'
+            bundler: '2.3.26'
+          - ruby: '3.0'
+            bundler: '2.3.26'
 
     steps:
       - uses: actions/checkout@v4
@@ -30,5 +41,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          bundler: ${{ matrix.bundler }}
       - name: Run the default task
         run: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PocketFlow Ruby
 
-PocketFlow Ruby is a minimal, synchronous workflow library for Ruby 3.4+, **ported from the excellent [PocketFlow project](https://github.com/The-Pocket/PocketFlow)** by [The Pocket](https://www.thepocket.io/). This version draws inspiration primarily from the TypeScript implementation and reimagines it using idiomatic Ruby and plain-old Ruby objects. It aims to maintain API consistency across languages while being lightweight and extensible.
+PocketFlow Ruby is a minimal, synchronous workflow library for Ruby 2.5+, **ported from the excellent [PocketFlow project](https://github.com/The-Pocket/PocketFlow)** by [The Pocket](https://www.thepocket.io/). This version draws inspiration primarily from the TypeScript implementation and reimagines it using idiomatic Ruby and plain-old Ruby objects. It aims to maintain API consistency across languages while being lightweight and extensible.
 
 > [!NOTE]
 > This library is a community-maintained port and is not affiliated with or officially supported by the original PocketFlow maintainers.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PocketFlow Ruby
 
-PocketFlow Ruby is a minimal, synchronous workflow library for Ruby 2.5+, **ported from the excellent [PocketFlow project](https://github.com/The-Pocket/PocketFlow)** by [The Pocket](https://www.thepocket.io/). This version draws inspiration primarily from the TypeScript implementation and reimagines it using idiomatic Ruby and plain-old Ruby objects. It aims to maintain API consistency across languages while being lightweight and extensible.
+PocketFlow Ruby is a minimal, synchronous workflow library for Ruby 2.7+, **ported from the excellent [PocketFlow project](https://github.com/The-Pocket/PocketFlow)** by [The Pocket](https://www.thepocket.io/). This version draws inspiration primarily from the TypeScript implementation and reimagines it using idiomatic Ruby and plain-old Ruby objects. It aims to maintain API consistency across languages while being lightweight and extensible.
 
 > [!NOTE]
 > This library is a community-maintained port and is not affiliated with or officially supported by the original PocketFlow maintainers.

--- a/lib/pocketflow.rb
+++ b/lib/pocketflow.rb
@@ -241,7 +241,7 @@ module Pocketflow
     # Internal: Clone this node for use in a thread, preserving state
     def clone_for_thread
       # Use Object#clone to preserve singleton methods and instance variables
-      cloned = Object.instance_method(:clone).bind(self).call
+      cloned = clone
       cloned.instance_variable_set(:@params, @params.dup) if @params
       cloned
     end

--- a/lib/pocketflow.rb
+++ b/lib/pocketflow.rb
@@ -28,6 +28,9 @@ module Pocketflow
   # Public: Default action name used when a node's +post+ does not specify one.
   DEFAULT_ACTION = "default"
 
+  # Public: Default action name used by batch processing nodes to indicate completion.
+  PROCESSED_ACTION = "processed"
+
   # Public: BaseNode is the minimal building block of a Pocketflow graph.
   #
   # A node's lifecycle is **prep → exec → post**. Override those hooks to
@@ -392,7 +395,7 @@ module Pocketflow
 
       # Now run the successor nodes (like aggregator) with the merged results
       if @start.successors.any?
-        action = "processed"  # Default action from processor nodes
+        action = PROCESSED_ACTION  # Default action from processor nodes
         current = @start.get_next_node(action)&.clone
         while current
           current.set_params(@params)

--- a/lib/pocketflow.rb
+++ b/lib/pocketflow.rb
@@ -2,7 +2,7 @@
 
 require 'set'
 
-# Public: Pocketflow – A tiny, synchronous workflow library for Ruby 2.5+.
+# Public: Pocketflow – A tiny, synchronous workflow library for Ruby 2.7+.
 #
 # The library mirrors sibling implementations in TypeScript, Python, Go and
 # Java while embracing plain‑old Ruby objects and language idioms. "Parallel"

--- a/lib/pocketflow.rb
+++ b/lib/pocketflow.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Public: Pocketflow – A tiny, synchronous workflow library for Ruby 3.4+.
+# Public: Pocketflow – A tiny, synchronous workflow library for Ruby 2.5+.
 #
 # The library mirrors sibling implementations in TypeScript, Python, Go and
 # Java while embracing plain‑old Ruby objects and language idioms. "Parallel"
@@ -85,14 +85,18 @@ module Pocketflow
     # shared - The shared context passed through the entire flow.
     #
     # Returns an arbitrary prep object.
-    def prep(shared) = nil
+    def prep(shared)
+      nil
+    end
 
     # Public: Perform the primary work. Override in subclasses.
     #
     # prep_res - The value returned by +prep+.
     #
     # Returns an arbitrary execution result.
-    def exec(prep_res) = nil
+    def exec(prep_res)
+      nil
+    end
 
     # Public: Process results and decide the next action. Override in subclasses.
     #
@@ -101,7 +105,9 @@ module Pocketflow
     # exec_res  - The object returned by +exec+.
     #
     # Returns the String action name or +nil+ / DEFAULT_ACTION.
-    def post(shared, prep_res, exec_res) = nil
+    def post(shared, prep_res, exec_res)
+      nil
+    end
 
     # Internal: Wrapper around the node lifecycle.
     #
@@ -120,7 +126,9 @@ module Pocketflow
     # prep_res - The object returned by +prep+.
     #
     # Returns whatever +exec+ returns.
-    def exec_internal(prep_res) = exec(prep_res)
+    def exec_internal(prep_res)
+      exec(prep_res)
+    end
 
     # Public: Execute this node as a standalone unit.
     #
@@ -312,7 +320,9 @@ module Pocketflow
     end
 
     # Public: Override to supply an Array of Hash‑like parameter sets.
-    def prep(shared) = []
+    def prep(shared)
+      []
+    end
   end
 
   # Public: ParallelBatchFlow runs batch flows concurrently using threads.

--- a/pocketflow.gemspec
+++ b/pocketflow.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "PocketFlow Ruby is a minimal workflow orchestration library designed around a simple node-graph execution model, with Thread-based concurrency for I/O-bound operations."
   spec.homepage = "https://github.com/jonmagic/PocketFlow-Ruby"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/pocketflow.gemspec
+++ b/pocketflow.gemspec
@@ -8,11 +8,11 @@ Gem::Specification.new do |spec|
   spec.authors = ["Jonathan Hoyt"]
   spec.email = ["jonmagic@gmail.com"]
 
-  spec.summary = "pocketflow.rb is a Ruby port of the original Python version - a minimalist LLM framework."
-  spec.description = "Pocket Flow: A minimalist LLM framework. Let Agents build Agents!"
+  spec.summary = "A minimal, synchronous workflow library, ported from PocketFlow TypeScript."
+  spec.description = "PocketFlow Ruby is a minimal workflow orchestration library designed around a simple node-graph execution model, with Thread-based concurrency for I/O-bound operations."
   spec.homepage = "https://github.com/jonmagic/PocketFlow-Ruby"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/test/batch_flow_test.rb
+++ b/test/batch_flow_test.rb
@@ -11,7 +11,9 @@ class AsyncDataProcessNode < Pocketflow::Node
     data
   end
 
-  def exec(prep_res) = prep_res
+  def exec(prep_res)
+    prep_res
+  end
 
   def post(shared, _prep_res, exec_res)
     key = @params[:key]

--- a/test/concurrency_performance_test.rb
+++ b/test/concurrency_performance_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "benchmark"
+
+class ConcurrencyPerformanceTest < Minitest::Test
+  class SlowProcessor < Pocketflow::BatchNode
+    def prep(shared)
+      shared[:numbers] || []
+    end
+
+    def exec(item)
+      sleep 0.1  # Simulate I/O operation
+      item * 2
+    end
+
+    def post(shared, _prep, exec_res)
+      shared[:results] = exec_res
+      nil
+    end
+  end
+
+  class ParallelSlowProcessor < Pocketflow::ParallelBatchNode
+    def prep(shared)
+      shared[:numbers] || []
+    end
+
+    def exec(item)
+      sleep 0.1  # Simulate I/O operation
+      item * 2
+    end
+
+    def post(shared, _prep, exec_res)
+      shared[:results] = exec_res
+      nil
+    end
+  end
+
+  def test_parallel_performance_improvement
+    numbers = [1, 2, 3, 4, 5]  # 5 items with 0.1s each = ~0.5s sequential
+
+    # Test sequential processing
+    shared_seq = { numbers: numbers }
+    sequential_time = Benchmark.realtime do
+      SlowProcessor.new.run(shared_seq)
+    end
+
+    # Test parallel processing
+    shared_par = { numbers: numbers }
+    parallel_time = Benchmark.realtime do
+      ParallelSlowProcessor.new.run(shared_par)
+    end
+
+    # Results should be the same
+    assert_equal [2, 4, 6, 8, 10], shared_seq[:results]
+    assert_equal [2, 4, 6, 8, 10], shared_par[:results]
+
+    # Parallel should be significantly faster (allowing some overhead)
+    # Sequential: ~0.5s, Parallel: ~0.1s (plus thread overhead)
+    assert parallel_time < sequential_time * 0.5,
+           "Parallel time (#{parallel_time}s) should be much less than sequential time (#{sequential_time}s)"
+  end
+end

--- a/test/skip_keys_test.rb
+++ b/test/skip_keys_test.rb
@@ -1,0 +1,167 @@
+require_relative "test_helper"
+
+class SkipKeysTest < Minitest::Test
+  def test_default_skip_keys_behavior
+    # Node that processes batch data and adds various keys to shared context
+    processor = Class.new(Pocketflow::Node) do
+      def prep(shared)
+        # Get the batch data for this batch ID
+        batch_id = @params[:batch_id]
+        shared[:input_data][batch_id] if shared[:input_data]
+      end
+
+      def exec(batch_item)
+        "processed_#{batch_item}"
+      end
+
+      def post(shared, prep_res, exec_res)
+        batch_id = @params[:batch_id]
+
+        # Store results (should be merged)
+        shared[:results] ||= {}
+        shared[:results][batch_id] = exec_res
+
+        # Add input-like keys (should be skipped by default patterns)
+        shared[:some_input] = "should_be_skipped"
+        shared[:user_input] = "also_skipped"
+
+        # Add output data (should be kept)
+        shared[:output_data] = "should_be_kept"
+
+        "processed"
+      end
+    end
+
+    # Custom ParallelBatchFlow that creates batch parameters
+    flow_class = Class.new(Pocketflow::ParallelBatchFlow) do
+      def prep(shared)
+        # Create batch parameters for each input item
+        shared[:input_data].each_index.map { |i| { batch_id: i } }
+      end
+    end
+
+    flow = flow_class.new(processor.new)
+
+    # Initialize shared context with input data
+    shared = {
+      input_data: ["item1", "item2"],
+      batches: ["original_batches"],  # Should be preserved by default skip
+      existing_data: "preserved"
+    }
+
+    flow.run(shared)
+
+    # Check that results were merged correctly
+    expected_results = { 0 => "processed_item1", 1 => "processed_item2" }
+    assert_equal expected_results, shared[:results]
+
+    # Check that output data was merged
+    assert_equal "should_be_kept", shared[:output_data]
+
+    # Check that default skip patterns worked
+    assert_equal ["original_batches"], shared[:batches]  # Original batches preserved
+    assert_equal "preserved", shared[:existing_data]     # Original data preserved
+
+    # Keys ending with _input should be skipped
+    refute shared.key?(:some_input)
+    refute shared.key?(:user_input)
+  end
+
+  def test_custom_skip_keys
+    processor = Class.new(Pocketflow::Node) do
+      def prep(shared)
+        @params[:data]
+      end
+
+      def exec(data)
+        "processed_#{data}"
+      end
+
+      def post(shared, prep_res, exec_res)
+        shared[:results] ||= []
+        shared[:results] << exec_res
+
+        # These should be skipped due to custom skip_keys
+        shared[:config_data] = "should_be_skipped"
+        shared[:raw_data] = "should_be_skipped"
+
+        # This should be kept
+        shared[:processed_data] = "should_be_kept"
+
+        "processed"
+      end
+    end
+
+    flow_class = Class.new(Pocketflow::ParallelBatchFlow) do
+      def prep(shared)
+        [{ data: "item1" }, { data: "item2" }]
+      end
+    end
+
+    # Setup with custom skip keys
+    flow = flow_class.new(
+      processor.new,
+      skip_keys: ["config_data", "raw_data"]
+    )
+
+    shared = { initial_data: "preserved" }
+    flow.run(shared)
+
+    # Custom skip keys should be honored
+    refute shared.key?(:config_data)
+    refute shared.key?(:raw_data)
+
+    # Non-skipped data should be present
+    assert shared[:results].length == 2
+    assert shared[:results].all? { |r| r.start_with?("processed_") }
+    assert_equal "should_be_kept", shared[:processed_data]
+    assert_equal "preserved", shared[:initial_data]
+  end
+
+  def test_empty_skip_keys_merges_everything
+    processor = Class.new(Pocketflow::Node) do
+      def prep(shared)
+        @params[:data]
+      end
+
+      def exec(data)
+        "result_#{data}"
+      end
+
+      def post(shared, prep_res, exec_res)
+        # These would normally be skipped but shouldn't be with empty skip_keys
+        # Since we only have one thread, these should be the final values
+        shared[:some_input] = "merged"
+        shared[:user_input] = "also_merged"
+        shared[:batches] = ["new_batches"]
+        shared[:result] = exec_res
+
+        "processed"
+      end
+    end
+
+    flow_class = Class.new(Pocketflow::ParallelBatchFlow) do
+      def prep(shared)
+        [{ data: "item1" }]
+      end
+    end
+
+    # No skip keys - everything should be merged
+    flow = flow_class.new(processor.new, skip_keys: [])
+
+    shared = {
+      batches: ["original"],
+      existing_data: "original"
+    }
+
+    flow.run(shared)
+
+    # With empty skip_keys, input-like keys should be merged
+    # Since we have only one batch/thread, the values should be present
+    assert_equal "merged", shared[:some_input]
+    assert_equal "also_merged", shared[:user_input]
+    assert_equal ["new_batches"], shared[:batches]  # Original was overwritten
+    assert_equal "original", shared[:existing_data] # This wasn't touched by threads
+    assert_equal "result_item1", shared[:result]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,10 @@ require "pocketflow"
 
 require "minitest/autorun"
 
+# Suppress noisy thread exception reports during tests
+# Exception handling in parallel nodes is expected behavior
+Thread.report_on_exception = false
+
 # Shared constants used across tests
 SharedStorage = Hash unless defined?(SharedStorage)
 BatchParams = Hash unless defined?(BatchParams)


### PR DESCRIPTION
## Why?
Previously, ParallelBatchNode and ParallelBatchFlow simulated concurrency, but did not utilize true thread-based parallelism. This resulted in inefficiencies for I/O-bound batch tasks, as batch items were still processed sequentially, limiting the performance gains of parallel batching.

## How?
- Refactors ParallelBatchNode and ParallelBatchFlow to run batch items/flows using Ruby threads, enabling real concurrent execution for I/O-bound workloads.
- Ensures thread safety by cloning node instances per-thread and merging contexts upon completion ([`lib/pocketflow.rb`](lib/pocketflow.rb), commit 12088e2).
- Updates documentation and adds unit tests to demonstrate and validate improved concurrency and speedup ([`test/concurrency_performance_test.rb`](test/concurrency_performance_test.rb), [`README.md`](README.md)).

### Testing
- Added `concurrency_performance_test.rb` to benchmark and verify concurrent execution.
- Updated existing unit tests for ParallelBatchNode to cover thread-safety and correctness.
